### PR TITLE
fix multiline

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -400,8 +400,8 @@ func (ftp *FTP) receive() (string, error) {
 			if err != nil {
 				return line, err
 			}
-			code, _, err := ftp.getCode(str)
-			if err == nil && code == closingCode {
+			code, ml, err := ftp.getCode(str)
+			if err == nil && !ml && code == closingCode {
 				break
 			} else {
 				//check error codes 5xx 4xx


### PR DESCRIPTION
skip next lines after first multiline if they start with code then "minus" until  line with code without "minus"
Like this. Now it works with ftp.musicbrainz.org:21

220-
220-      Questions/Comments/Suggestions/Co
220-
220----------------------------------------
220
