### PR TITLE
fix parseUnixLIST

### DIFF
--- a/ftp_list.go
+++ b/ftp_list.go
@@ -155,7 +155,7 @@ func (ftp *FTP) parseNLST(data []string, basePath string) (files []string, direc
 // Parse the response of a LIST
 // Return an array with the files, one with the directories and one with the links
 func (ftp *FTP) parseUnixLIST(data []string, basePath string) (files []string, directories []string, links []string, err error) {
-	var pattern = regexp.MustCompile(`([-ld])([-rwx]+)\s{2,}\d+\s(\d|\w+)\s{2,}(\(\?\)|\d+|\w+)\s{2,}(\d+)\s*(\w+\s*\d+\s*\d+\:*\d*)\s(\S+)`)
+	var pattern = regexp.MustCompile(`([-ld])([-rwx]+)\s{2,}\d+\s(\d|\w+)\s{2,}(\(\?\)|\d+|[\w\-]+)\s{1,}(\d+)\s*(\w+\s*\d+\s*\d+\:*\d*)\s(\S+)`)
 	for _, line := range data {
 		match := pattern.FindStringSubmatch(line)
 		/*for i, val := range match {

--- a/ftp_list.go
+++ b/ftp_list.go
@@ -155,7 +155,14 @@ func (ftp *FTP) parseNLST(data []string, basePath string) (files []string, direc
 // Parse the response of a LIST
 // Return an array with the files, one with the directories and one with the links
 func (ftp *FTP) parseUnixLIST(data []string, basePath string) (files []string, directories []string, links []string, err error) {
-	var pattern = regexp.MustCompile(`([-ld])([-rwx]+)\s{2,}\d+\s(\d|\w+)\s{2,}(\(\?\)|\d+|[\w\-]+)\s{1,}(\d+)\s*(\w+\s*\d+\s*\d+\:*\d*)\s(\S+)`)
+	var pattern = regexp.MustCompile(`([-ld])` + //dir,link flags -dbclps
+		`([-rwxs]+)\s+` + //permissions
+		`\d+\s+` + //items count
+		`([\d\w\-]+)\s+` + //owner
+		`(\(\?\)|[\d\w\-]+)\s+` + //group
+		`(\d+)\s*` + //size
+		`(\w+\s*\d+\s*\d+\:*\d*)\s+` + //date|time
+		`(\S+)` /*name*/)
 	for _, line := range data {
 		match := pattern.FindStringSubmatch(line)
 		/*for i, val := range match {


### PR DESCRIPTION
parseUnixLIST fails:
1. if "-"-char in group, eg. FU-Berlin
2. if one space between group and size

```
  drwxr-xr-x  16 ZEDAT    FU-Berlin     4096 Jul  8  2005 doc
  -rw-r--r--   1 ZEDAT    FU-Berlin 60517524 Jan  3 01:56 du-k
```
